### PR TITLE
Fixes missing Request Depot when using Transport Drones

### DIFF
--- a/modfiles/changelog.txt
+++ b/modfiles/changelog.txt
@@ -6,7 +6,7 @@ Date: 00. 00. 0000
   Changes:
     -
   Bugfixes:
-    -
+    - Fixed an issue where Request Depots from Klonan's Transport Drones could not be selected a product (Thanks MCP!)
 
 ---------------------------------------------------------------------------------------------------
 Version: 1.1.20

--- a/modfiles/data/handlers/generator.lua
+++ b/modfiles/data/handlers/generator.lua
@@ -40,8 +40,8 @@ function generator.all_recipes()
       {filter="energy", comparison="<", value=1e+21, mode="and"}}
     for recipe_name, proto in pairs(game.get_filtered_recipe_prototypes(recipe_filter)) do
         local category_id = NEW.all_machines.map[proto.category]
-        -- Avoid any recipes that have no machine to produce them, or are annoying
-        if category_id ~= nil and not generator_util.is_annoying_recipe(proto) then
+        -- Avoid any recipes that have no machine to produce them, or are irrelevant
+        if category_id ~= nil and not generator_util.is_irrelevant_recipe(proto) then
             local recipe = {
                 name = proto.name,
                 category = proto.category,

--- a/modfiles/data/handlers/generator_util.lua
+++ b/modfiles/data/handlers/generator_util.lua
@@ -293,19 +293,19 @@ local irrelevant_recipe_categories = {
     ["Mining_Drones"] = {"mining-depot"}
 }
 
--- Precompute the lookup by recipe category for performance
+-- Precompute the lookup table by recipe category for performance
 local irrelevant_recipe_categories_precompute_lookup = {}
+local active_mods = script.active_mods
 for mod, categories in pairs(irrelevant_recipe_categories) do
     for _, category in pairs(categories) do
-        if script.active_mods[mod] then
+        if active_mods[mod] then
             irrelevant_recipe_categories_precompute_lookup[category] = true
         end
     end
 end
 
--- Determines whether this recipe is irrelevant or not, and thus should be excluded
--- from Factory Planner
--- Compatible with: Klonan's Transport/Mining Drones
+-- Determines whether this recipe is irrelevant or not and should thus be excluded
+-- Compatible with: Klonan's Transport+Mining Drones
 function generator_util.is_irrelevant_recipe(recipe)
     return irrelevant_recipe_categories_precompute_lookup[recipe.category]
 end

--- a/modfiles/data/handlers/generator_util.lua
+++ b/modfiles/data/handlers/generator_util.lua
@@ -287,16 +287,28 @@ function generator_util.is_barreling_recipe(proto)
     end
 end
 
--- Determines whether this recipe is annoying or not
--- Compatible with: Klonan's Transport/Mining Drones
-function generator_util.is_annoying_recipe(proto)
-    if string.match(proto.name, "^request%-.*") or string.match(proto.name, "^mine%-.*") then
-        return true
-    else
-        return false
+-- A table of mods and the recipe categories in them that are annoying
+local annoying_recipe_categories = {
+    ["Transport_Drones"] = {"transport-drone-request", "transport-fluid-request"},
+    ["Mining_Drones"] = {"mining-depot"}
+}
+
+-- Precompute the lookup by recipe category for performance
+local annoying_recipe_categories_precompute_lookup = {}
+for mod, categories in pairs(annoying_recipe_categories) do
+    for _, category in pairs(categories) do
+        if script.active_mods[mod] then
+            annoying_recipe_categories_precompute_lookup[category] = true
+        end
     end
 end
 
+-- Determines whether this recipe is annoying or not, and thus should be excluded
+-- from Factory Planner
+-- Compatible with: Klonan's Transport/Mining Drones
+function generator_util.is_annoying_recipe(recipe)
+    return annoying_recipe_categories_precompute_lookup[recipe.category]
+end
 
 -- Finds a sprite for the given entity prototype
 function generator_util.determine_entity_sprite(proto)

--- a/modfiles/data/handlers/generator_util.lua
+++ b/modfiles/data/handlers/generator_util.lua
@@ -287,27 +287,27 @@ function generator_util.is_barreling_recipe(proto)
     end
 end
 
--- A table of mods and the recipe categories in them that are annoying
-local annoying_recipe_categories = {
+-- A table of mods and the recipe categories in them that are irrelevant
+local irrelevant_recipe_categories = {
     ["Transport_Drones"] = {"transport-drone-request", "transport-fluid-request"},
     ["Mining_Drones"] = {"mining-depot"}
 }
 
 -- Precompute the lookup by recipe category for performance
-local annoying_recipe_categories_precompute_lookup = {}
-for mod, categories in pairs(annoying_recipe_categories) do
+local irrelevant_recipe_categories_precompute_lookup = {}
+for mod, categories in pairs(irrelevant_recipe_categories) do
     for _, category in pairs(categories) do
         if script.active_mods[mod] then
-            annoying_recipe_categories_precompute_lookup[category] = true
+            irrelevant_recipe_categories_precompute_lookup[category] = true
         end
     end
 end
 
--- Determines whether this recipe is annoying or not, and thus should be excluded
+-- Determines whether this recipe is irrelevant or not, and thus should be excluded
 -- from Factory Planner
 -- Compatible with: Klonan's Transport/Mining Drones
-function generator_util.is_annoying_recipe(recipe)
-    return annoying_recipe_categories_precompute_lookup[recipe.category]
+function generator_util.is_irrelevant_recipe(recipe)
+    return irrelevant_recipe_categories_precompute_lookup[recipe.category]
 end
 
 -- Finds a sprite for the given entity prototype


### PR DESCRIPTION
FP used to use a regex to match irrelevant recipes. This caught a relevant recipe in its net, so change to using a set of recipe categories instead.

Related links:
https://trello.com/c/RmLQKQ5T
https://mods.factorio.com/mod/factoryplanner/discussion/605406fd75bbfc0c6eb48069