### PR TITLE
Code cleanup: Remove uncapped production ratio

### DIFF
--- a/modfiles/data/calculation/interface.lua
+++ b/modfiles/data/calculation/interface.lua
@@ -18,7 +18,6 @@ local function set_blank_line(player, floor, line)
         energy_consumption = 0,
         pollution = 0,
         production_ratio = (not line.subfloor) and 0 or nil,
-        uncapped_production_ratio = (not line.subfloor) and 0 or nil,
         Product = blank_class,
         Byproduct = blank_class,
         Ingredient = blank_class,
@@ -277,7 +276,6 @@ function calculation.interface.set_line_result(result)
         if line.machine.fuel ~= nil then line.machine.fuel.amount = result.fuel_amount end
 
         line.production_ratio = result.production_ratio
-        line.uncapped_production_ratio = result.uncapped_production_ratio
 
         -- Reset the priority_product if there's only one product
         if structures.class.count(result.Product) == 1 then line.priority_product_proto = nil end

--- a/modfiles/data/calculation/matrix_solver.lua
+++ b/modfiles/data/calculation/matrix_solver.lua
@@ -396,7 +396,6 @@ function matrix_solver.run_matrix_solver(subfactory_data, check_linear_dependenc
                 energy_consumption = line_aggregate.energy_consumption,
                 pollution = line_aggregate.pollution,
                 production_ratio = line_aggregate.production_ratio,
-                uncapped_production_ratio = line_aggregate.uncapped_production_ratio,
                 Product = line_aggregate.Product,
                 Byproduct = line_aggregate.Byproduct,
                 Ingredient = line_aggregate.Ingredient,
@@ -634,7 +633,6 @@ function matrix_solver.get_line_aggregate(line_data, player_index, floor_id, mac
     local in_game_crafts_per_second = math.min(unmodified_crafts_per_second, 60)
     local total_crafts_per_timescale = timescale * machine_count * in_game_crafts_per_second
     line_aggregate.production_ratio = total_crafts_per_timescale
-    line_aggregate.uncapped_production_ratio = total_crafts_per_timescale
     for _, product in pairs(recipe_proto.products) do
         local prodded_amount = calculation.util.determine_prodded_amount(product, unmodified_crafts_per_second, total_effects)
         local item_key = matrix_solver.get_item_key(product.type, product.name)

--- a/modfiles/data/calculation/sequential_solver.lua
+++ b/modfiles/data/calculation/sequential_solver.lua
@@ -17,7 +17,7 @@ local function update_line(line_data, aggregate)
     end
 
     -- Determine production ratio
-    local production_ratio, uncapped_production_ratio = 0, 0
+    local production_ratio = 0
     local crafts_per_tick = calculation.util.determine_crafts_per_tick(machine_proto, recipe_proto, total_effects)
 
     -- Determines the production ratio that would be needed to fully satisfy the given product
@@ -49,7 +49,6 @@ local function update_line(line_data, aggregate)
             end
         end
     end
-    uncapped_production_ratio = production_ratio  -- retain the uncapped ratio for line_data
 
     -- Limit the machine_count by reducing the production_ratio, if necessary
     local machine_limit = line_data.machine_limit
@@ -162,7 +161,6 @@ local function update_line(line_data, aggregate)
         energy_consumption = energy_consumption,
         pollution = pollution,
         production_ratio = production_ratio,
-        uncapped_production_ratio = uncapped_production_ratio,
         Product = Product,
         Byproduct = Byproduct,
         Ingredient = Ingredient,
@@ -225,7 +223,6 @@ local function update_floor(floor_data, aggregate)
                 energy_consumption = subfloor_aggregate.energy_consumption,
                 pollution = subfloor_aggregate.pollution,
                 production_ratio = nil,
-                uncapped_production_ratio = nil,
                 Product = subfloor_aggregate.Product,
                 Byproduct = subfloor_aggregate.Byproduct,
                 Ingredient = subfloor_aggregate.Ingredient,

--- a/modfiles/data/calculation/structures.lua
+++ b/modfiles/data/calculation/structures.lua
@@ -12,7 +12,6 @@ function structures.aggregate.init(player_index, floor_id)
         energy_consumption = 0,
         pollution = 0,
         production_ratio = nil,
-        uncapped_production_ratio = nil,
         Product = structures.class.init(),
         Byproduct = structures.class.init(),
         Ingredient = structures.class.init()

--- a/modfiles/data/classes/Line.lua
+++ b/modfiles/data/classes/Line.lua
@@ -21,7 +21,6 @@ function Line.init(recipe)
         priority_product_proto = nil,  -- set by the user
         comment = nil,
         production_ratio = (is_standalone_line) and 0 or nil,
-        uncapped_production_ratio = (is_standalone_line) and 0 or nil,
         subfloor = nil,
         valid = true,
         class = "Line"

--- a/modfiles/ui/dialogs/machine_dialog.lua
+++ b/modfiles/ui/dialogs/machine_dialog.lua
@@ -16,15 +16,16 @@ local function refresh_machine_frame(player)
     local current_proto = dialog_machine.proto
 
     local round_button_numbers = data_util.get("preferences", player).round_button_numbers
-    local timescale = ui_state.context.subfactory.timescale
 
+    local existing_crafts_per_tick = calculation.util.determine_crafts_per_tick(
+        line.machine.proto, line.recipe.proto, line.total_effects)
+    local existing_machine_count = line.machine.count
     for _, machine_proto in ipairs(category_prototypes) do
         if Line.is_machine_applicable(line, machine_proto) then
             -- Need to get total effects here to include mining productivity
             local crafts_per_tick = calculation.util.determine_crafts_per_tick(machine_proto,
               line.recipe.proto, line.total_effects)
-            local machine_count = calculation.util.determine_machine_count(crafts_per_tick,
-              line.uncapped_production_ratio, timescale, machine_proto.launch_sequence_time)
+            local machine_count = existing_machine_count * existing_crafts_per_tick / crafts_per_tick
 
             local button_number = (round_button_numbers) and math.ceil(machine_count) or machine_count
 

--- a/modfiles/ui/elements/production_table.lua
+++ b/modfiles/ui/elements/production_table.lua
@@ -143,7 +143,7 @@ function builders.machine(line, parent_flow, metadata)
             if line.machine.force_limit then
                 style = "flib_slot_button_pink_small"
                 note = {"fp.machine_limit_force", machine_limit}
-            elseif line.production_ratio < line.uncapped_production_ratio then
+            elseif line.machine.count == line.machine.limit then
                 style = "flib_slot_button_orange_small"
                 note = {"fp.machine_limit_enforced", machine_limit}
             else


### PR DESCRIPTION
The `uncapped_production_ratio` property is highly dependent on the inner workings of the sequential solver. Removing the property and making the affected features unreliant on it will make the code simpler and more solver-agnostic.

Side effect: the uncapped machine count being equal to the machine limit will count as hitting the limit. This change is unavoidable, as far as I can tell, but I do not consider the new behavior unreasonable.