### PR TITLE
remove items within rounding error of zero in structures.class.add

### DIFF
--- a/modfiles/data/calculation/structures.lua
+++ b/modfiles/data/calculation/structures.lua
@@ -56,7 +56,7 @@ function structures.class.add(class, item, amount)
 
     local type_table = class[type]
     type_table[name] = (type_table[name] or 0) + amount_to_add
-    if type_table[name] == 0 then type_table[name] = nil end
+    if math.abs(type_table[name]) < 1e-10 then type_table[name] = nil end
 end
 
 function structures.class.subtract(class, item, amount)


### PR DESCRIPTION
I looked into OneWheelDude's issue with -1's appearing as products. These only seemed to occur on subfloors, and upon further investigation I noticed the values were all really close to zero (typically around 10^-14 or 10^-15). I'm not really sure why they weren't being displayed as close to zero (maybe the UI can't handle scientific notation?). In any case, I found that `structures.class.add` should drop items that solved to zero, so I changed this code to check if the value is within 10^-10 of zero instead.