### PR TITLE
count only unfinished components in utility dialog

### DIFF
--- a/modfiles/data/classes/Floor.lua
+++ b/modfiles/data/classes/Floor.lua
@@ -112,8 +112,9 @@ end
 
 
 -- Returns the machines and modules needed to actually build this floor
-function Floor.get_component_data(self, component_table)
+function Floor.get_component_data(self, component_table, only_unfinished)
     local components = component_table or {machines={}, modules={}}
+    only_unfinished = only_unfinished or false
 
     local function add_component(table, proto, amount)
         local component = table[proto.name]
@@ -132,7 +133,7 @@ function Floor.get_component_data(self, component_table)
     -- Doesn't count subfloors when looking at this specific floors. Maybe it should, which
     -- would mean the subfactory machine total is equal to the floor total of the top floor
     for _, line in pairs(Floor.get_in_order(self, "Line")) do
-        if line.subfloor == nil then
+        if line.subfloor == nil and not (only_unfinished and line.done) then
             local machine = line.machine
             local ceil_machine_count = math.ceil(machine.count - 0.001)
 
@@ -154,6 +155,11 @@ function Floor.get_component_data(self, component_table)
     end
 
     return components
+end
+
+-- Returns the machines and modules remaining to actually build this floor
+function Floor.get_unfinished_component_data(self, component_table)
+    return Floor.get_component_data(self, component_table, true)
 end
 
 

--- a/modfiles/data/classes/Subfactory.lua
+++ b/modfiles/data/classes/Subfactory.lua
@@ -115,7 +115,19 @@ function Subfactory.get_component_data(self)
 
     for _, floor in pairs(Subfactory.get_in_order(self, "Floor")) do
         -- Relies on the floor-function to do the heavy lifting
-        Floor.get_component_data(floor, components)
+        Floor.get_component_data(floor, components, false)
+    end
+
+    return components
+end
+
+-- Returns the machines and modules remaining to actually build this subfactory
+function Subfactory.get_unfinished_component_data(self)
+    local components = {machines={}, modules={}}
+
+    for _, floor in pairs(Subfactory.get_in_order(self, "Floor")) do
+        -- Relies on the floor-function to do the heavy lifting
+        Floor.get_component_data(floor, components, true)
     end
 
     return components

--- a/modfiles/ui/dialogs/utility_dialog.lua
+++ b/modfiles/ui/dialogs/utility_dialog.lua
@@ -117,7 +117,13 @@ function utility_structures.components(player, modal_data)
         component_row.clear()
 
         local inventory_contents = modal_data.inventory_contents
-        local component_data = _G[scope].get_component_data(context[lower_scope], nil)
+
+        local component_data
+        if data_util.get("preferences", player).done_column then
+            component_data = _G[scope].get_unfinished_component_data(context[lower_scope], nil)
+        else
+            component_data = _G[scope].get_component_data(context[lower_scope], nil)
+        end
 
         local frame_components = component_row.add{type="frame", direction="horizontal", style="slot_button_deep_frame"}
         local table_components = frame_components.add{type="table", column_count=10, style="filter_slot_table"}


### PR DESCRIPTION
this PR adds `get_unfinished_component_data` functions to `Subfactory` and `Floor` that return only those components whose lines are not yet done.
it also modifies the utility dialog to use these functions (provided the checkbox column is turned on), so that the only components listed are those which are not yet placed.

(this can be implemented slightly more efficiently if #36 is merged)