### PR TITLE
switches for marking floors fully/partially/not at all done

### DIFF
--- a/modfiles/data/classes/Collection.lua
+++ b/modfiles/data/classes/Collection.lua
@@ -88,7 +88,7 @@ end
 -- Return format: {[gui_position] = dataset}
 function Collection.get_in_order(self, reverse)
     local ordered_datasets = {}
-    for _, dataset in pairs(self.datasets) do
+        for _, dataset in pairs(self.datasets) do
         local table_position = (reverse) and (self.count - dataset.gui_position + 1) or dataset.gui_position
         ordered_datasets[table_position] = dataset
     end

--- a/modfiles/ui/elements/compact_subfactory.lua
+++ b/modfiles/ui/elements/compact_subfactory.lua
@@ -95,12 +95,11 @@ local function add_checkmark_button(parent_flow, line, relevant_line)
     inner_flow.style.vertical_align = "center"
 
     if line.subfloor then
-        local status = Floor.get_done_status(line.subfloor)
         local switch_state, allow_none_state
-        if status == "none" then
+        if line.subfloor.done == "none" then
             switch_state = "left"
             allow_none_state = false
-        elseif status == "some" then
+        elseif line.subfloor.done == "some" then
             switch_state = "none"
             allow_none_state = true
         else
@@ -239,7 +238,7 @@ local function handle_compact_checkmark_change(player, tags, event)
         relevant_line.done = event.element.state
     end
 
-    Floor.recompute_origin_done_status_cascading_up(floor)
+    Floor.recompute_done_status_cascading_up(floor)
     compact_subfactory.refresh(player)
 end
 

--- a/modfiles/ui/elements/production_handler.lua
+++ b/modfiles/ui/elements/production_handler.lua
@@ -43,7 +43,7 @@ local function handle_checkmark_change(player, tags, event)
         relevant_line.done = event.element.state
     end
 
-    Floor.recompute_origin_done_status_cascading_up(floor)
+    Floor.recompute_done_status_cascading_up(floor)
     main_dialog.refresh(player, "production_detail")
 end
 

--- a/modfiles/ui/elements/production_table.lua
+++ b/modfiles/ui/elements/production_table.lua
@@ -45,12 +45,11 @@ function builders.done(line, parent_flow, _)
     local relevant_line = (line.subfloor) and line.subfloor.defining_line or line
 
     if line.subfloor then
-        local status = Floor.get_done_status(line.subfloor)
         local switch_state, allow_none_state
-        if status == "none" then
+        if line.subfloor.done == "none" then
             switch_state = "left"
             allow_none_state = false
-        elseif status == "some" then
+        elseif line.subfloor.done == "some" then
             switch_state = "none"
             allow_none_state = true
         else

--- a/modfiles/ui/elements/production_table.lua
+++ b/modfiles/ui/elements/production_table.lua
@@ -44,8 +44,26 @@ local builders = {}
 function builders.done(line, parent_flow, _)
     local relevant_line = (line.subfloor) and line.subfloor.defining_line or line
 
-    parent_flow.add{type="checkbox", state=relevant_line.done, mouse_button_filter={"left"},
-      tags={mod="fp", on_gui_checked_state_changed="checkmark_line", floor_id=line.parent.id, line_id=line.id}}
+    if line.subfloor then
+        local status = Floor.get_done_status(line.subfloor)
+        local switch_state, allow_none_state
+        if status == "none" then
+            switch_state = "left"
+            allow_none_state = false
+        elseif status == "some" then
+            switch_state = "none"
+            allow_none_state = true
+        else
+            switch_state = "right"
+            allow_none_state = false
+        end
+
+        parent_flow.add{type="switch", switch_state=switch_state, allow_none_state=allow_none_state,
+          tags={mod="fp", on_gui_switch_state_changed="checkmark_line", floor_id=line.parent.id, line_id=line.id}}
+    else
+        parent_flow.add{type="checkbox", state=relevant_line.done,
+          tags={mod="fp", on_gui_checked_state_changed="checkmark_line", floor_id=line.parent.id, line_id=line.id}}
+    end
 end
 
 function builders.recipe(line, parent_flow, metadata, indent)


### PR DESCRIPTION
i've tested this pretty thoroughly, and i'm pretty sure the state stays consistent whatever you do to it.

- [x] move the compact view checkmarks into their own ~~column~~ flow
- [x] hide the compact view checkmarks & disable greyscaling when turned off in preferences
- [x] store tristate done status in `Floor`s rather than recalculating several times per refresh