### PR TITLE
Update to dictionary-lite

### DIFF
--- a/modfiles/control.lua
+++ b/modfiles/control.lua
@@ -17,8 +17,7 @@ NEW = nil  -- global variable used to store new prototype data temporarily for m
 require("util")  -- core.lualib
 fancytable = require('__flib__.table')  -- has more functionality than built-in table
 
-translator = require("__flib__.dictionary")  -- translation module for localised search
---translator.set_use_local_storage(true)
+translator = require("__flib__.dictionary-lite")  -- translation module for localised search
 
 require("data.init")
 require("data.data_util")

--- a/modfiles/data/handlers/loader.lua
+++ b/modfiles/data/handlers/loader.lua
@@ -189,7 +189,6 @@ end
 function loader.run()
     data_util.nth_tick.register_all()
 
-    translator.load()
     --prototyper.util.build_translation_dictionaries()  -- necessary because we use local storage
 
     ORDERED_RECIPE_GROUPS = ordered_recipe_groups()

--- a/modfiles/data/handlers/prototyper.lua
+++ b/modfiles/data/handlers/prototyper.lua
@@ -115,15 +115,15 @@ end
 -- Build the necessary RawDictionaries for translation. Should be called after prototyper.finish().
 function prototyper.util.build_translation_dictionaries()
     for _, type in ipairs(global.all_items.types) do
-        local item_dictionary = translator.new(type.name)
+        translator.new(type.name)
         for _, proto in pairs(type.items) do
-            item_dictionary:add(proto.name, proto.localised_name)
+            translator.add(type.name, proto.name, proto.localised_name)
         end
     end
 
-    local recipe_dictionary = translator.new("recipe")
+    translator.new("recipe")
     for _, proto in pairs(global.all_recipes.recipes) do
-        recipe_dictionary:add(proto.name, proto.localised_name)
+        translator.add("recipe", proto.name, proto.localised_name)
     end
 end
 

--- a/modfiles/info.json
+++ b/modfiles/info.json
@@ -5,8 +5,8 @@
     "author": "Therenas",
     "factorio_version": "1.1",
     "dependencies": [
-        "base >= 1.1.4",
-        "flib >= 0.9.2",
+        "base >= 1.1.74",
+        "flib >= 0.12.0",
         "? RecipeBook"
     ]
 }


### PR DESCRIPTION
I think things should be good, but I wasn't able to test completely thoroughly.

dictionary-lite has a `handle_events()` function that adds all of the needed non-bootstrap handlers. I didn't use that here, instead opting to just replace the existing handlers and keep the `script` calls in factoryplanner.