### PR TITLE
Simplify beacon UI when beacon overload is active.

### DIFF
--- a/modfiles/changelog.txt
+++ b/modfiles/changelog.txt
@@ -6,6 +6,7 @@ Date: 00. 00. 0000
   Changes:
     - Added Ukranian translation (Thanks Met en Bouldry!)
     - Changed the ingredient combinator button to use a sprite instead of text
+    - Simplified the beacon UI when beacon overload is active
   Bugfixes:
     - Fixed that absurdly high module effects were not being capped correctly at the engine limit of +32767%
     - Fixed a few inconsistencies around raw ores and made them more visually distinct

--- a/modfiles/data/data_util.lua
+++ b/modfiles/data/data_util.lua
@@ -1,6 +1,10 @@
 data_util = {
     nth_tick = {},
-    porter = {}
+    porter = {},
+    is_beacon_overload_active = (
+        script.active_mods["space-exploration"] or
+        script.active_mods["wret-beacon-rebalance-mod"] or
+        script.active_mods["beacon-overhaul"]) and true
 }
 
 -- ** GETTER **

--- a/modfiles/ui/dialogs/beacon_dialog.lua
+++ b/modfiles/ui/dialogs/beacon_dialog.lua
@@ -18,7 +18,7 @@ local function add_beacon_frame(parent_flow, modal_data)
     button_beacon.style.right_margin = 12
     modal_elements["beacon_button"] = button_beacon
 
-    flow_beacon.add{type="label", caption={"fp.info_label", {"fp.amount"}}, tooltip={"fp.beacon_amount_tt"}}
+    local label_amount = flow_beacon.add{type="label", caption={"fp.info_label", {"fp.amount"}}, tooltip={"fp.beacon_amount_tt"}}
 
     local beacon_amount = (beacon.amount ~= 0) and tostring(beacon.amount) or ""
     local textfield_amount = flow_beacon.add{type="textfield", text=beacon_amount,
@@ -28,6 +28,12 @@ local function add_beacon_frame(parent_flow, modal_data)
     textfield_amount.style.width = 40
     textfield_amount.style.right_margin = 12
     modal_elements["beacon_amount"] = textfield_amount
+
+    if data_util.is_beacon_overload_active then
+        label_amount.visible = false
+        textfield_amount.visible = false
+        textfield_amount.text = "1"
+    end
 
     flow_beacon.add{type="label", caption={"fp.info_label", {"fp.beacon_total"}}, tooltip={"fp.beacon_total_tt"}}
 

--- a/modfiles/ui/elements/production_table.lua
+++ b/modfiles/ui/elements/production_table.lua
@@ -199,6 +199,9 @@ function builders.beacon(line, parent_flow, metadata)
         local button_beacon = parent_flow.add{type="sprite-button", sprite=beacon.proto.sprite, number=beacon.amount,
           tags={mod="fp", on_gui_click="act_on_line_beacon", floor_id=line.parent.id, line_id=line.id, type="beacon"},
           style="flib_slot_button_default_small", tooltip=tooltip, mouse_button_filter={"left-and-right"}}
+        if data_util.is_beacon_overload_active then  -- don't show beacon count if beacon overload is active
+          button_beacon.number = nil
+        end
 
         if beacon.total_amount ~= nil then  -- add a graphical hint that a beacon total is set
             local sprite_overlay = button_beacon.add{type="sprite", sprite="fp_sprite_white_square"}


### PR DESCRIPTION
Space Exploration (and some other other mods that offer the same feature in isolation) rebalances beacons, by only allowing machines to be covered by at most one beacon at a time (machines under the influence of two or more beacons are disabled instead).

In this context, the "amount" field in the beacon selection UI is not necessary, as the only legal value for it is 1. This change cleans up the UI and forces the beacon amount to be always 1.

(This change keeps the "total" field, as that is still relevant for power consumption calculations.)