### PR TITLE
Fix dataset iteration crash in migration 1.1.65

### DIFF
--- a/modfiles/backend/migrations/migration_1_1_65.lua
+++ b/modfiles/backend/migrations/migration_1_1_65.lua
@@ -4,7 +4,7 @@ local migration = {}
 
 function migration.player_table(player_table)
     for _, factory in pairs({"factory", "archive"}) do
-        for subfactory in pairs(player_table[factory].Subfactory.datasets) do
+        for _, subfactory in pairs(player_table[factory].Subfactory.datasets) do
             subfactory.blueprints = {}
         end
     end


### PR DESCRIPTION
Migration 1.1.65 would crash with this message because `subfactory` was the iteration index, not the value. (In my case, I was updating from 1.1.60 to 1.1.75)

![Screenshot 2023-11-24 at 9 58 43 AM](https://github.com/ClaudeMetz/FactoryPlanner/assets/3876970/e758fee9-47f0-4d74-861b-99e5841b79a1)
