### PR TITLE
Include burnt results in lines, to support Py ash and canisters.

### DIFF
--- a/modfiles/backend/calculation/matrix_engine.lua
+++ b/modfiles/backend/calculation/matrix_engine.lua
@@ -628,7 +628,7 @@ function matrix_engine.get_line_aggregate(line_data, player_index, floor_id, mac
     local total_crafts_per_timescale = timescale * machine_count * in_game_crafts_per_second
     line_aggregate.production_ratio = total_crafts_per_timescale
     line_aggregate.uncapped_production_ratio = total_crafts_per_timescale
-    for _, product in pairs(recipe_proto.products) do
+    for _, product in pairs(line_data.line_products) do
         local prodded_amount = solver_util.determine_prodded_amount(product, unmodified_crafts_per_second, total_effects)
         local item_key = matrix_engine.get_item_key(product.type, product.name)
         if factory_metadata~= nil and (factory_metadata.byproducts[item_key] or free_variables["item_"..item_key]) then

--- a/modfiles/backend/calculation/sequential_engine.lua
+++ b/modfiles/backend/calculation/sequential_engine.lua
@@ -10,7 +10,7 @@ local function update_line(line_data, aggregate)
 
     -- Determine relevant products
     local relevant_products, byproducts = {}, {}
-    for _, product in pairs(recipe_proto.products) do
+    for _, product in pairs(line_data.line_products) do
         if aggregate.Product[product.type][product.name] ~= nil then
             table.insert(relevant_products, product)
         else
@@ -179,7 +179,7 @@ local function update_floor(floor_data, aggregate)
         if subfloor ~= nil then
             -- Convert proto product table to class for easier and faster access
             local proto_products = structures.class.init()
-            for _, product in pairs(line_data.recipe_proto.products) do
+            for _, product in pairs(line_data.line_products) do
                 proto_products[product.type][product.name] = true
             end
 

--- a/modfiles/backend/calculation/sequential_engine.lua
+++ b/modfiles/backend/calculation/sequential_engine.lua
@@ -20,13 +20,13 @@ local function update_line(line_data, aggregate)
 
     -- Determine production ratio
     local production_ratio, uncapped_production_ratio = 0, 0
-    local crafts_per_tick = solver_util.determine_crafts_per_tick(machine_proto, recipe_proto, total_effects)
+    local crafts_per_second = solver_util.determine_crafts_per_second(machine_proto, recipe_proto, total_effects)
 
     -- Determines the production ratio that would be needed to fully satisfy the given product
     local function determine_production_ratio(relevant_product)
         local demand = aggregate.Product[relevant_product.type][relevant_product.name]
         local prodded_amount = solver_util.determine_prodded_amount(relevant_product,
-            crafts_per_tick, total_effects)
+            crafts_per_second, total_effects)
         return (demand * (line_data.percentage / 100)) / prodded_amount
     end
 
@@ -56,7 +56,7 @@ local function update_line(line_data, aggregate)
     -- Limit the machine_count by reducing the production_ratio, if necessary
     local machine_limit = line_data.machine_limit
     if machine_limit.limit ~= nil then
-        local capped_production_ratio = solver_util.determine_production_ratio(crafts_per_tick,
+        local capped_production_ratio = solver_util.determine_production_ratio(crafts_per_second,
             machine_limit.limit, timescale, machine_proto.launch_sequence_time)
         production_ratio = machine_limit.force_limit and capped_production_ratio
             or math.min(production_ratio, capped_production_ratio)
@@ -65,7 +65,7 @@ local function update_line(line_data, aggregate)
 
     -- Determines the amount of the given item, considering productivity
     local function determine_amount_with_productivity(item)
-        local prodded_amount = solver_util.determine_prodded_amount(item, crafts_per_tick, total_effects)
+        local prodded_amount = solver_util.determine_prodded_amount(item, crafts_per_second, total_effects)
         return prodded_amount * production_ratio
     end
 
@@ -116,7 +116,7 @@ local function update_line(line_data, aggregate)
 
 
     -- Determine machine count
-    local machine_count = solver_util.determine_machine_count(crafts_per_tick, production_ratio,
+    local machine_count = solver_util.determine_machine_count(crafts_per_second, production_ratio,
         timescale, machine_proto.launch_sequence_time)
 
     -- Add the integer machine count to the aggregate so it can be displayed on the origin_line

--- a/modfiles/backend/data/Floor.lua
+++ b/modfiles/backend/data/Floor.lua
@@ -185,7 +185,7 @@ function Floor:check_product_compatibility(object)
 
     local relevant_line = (object.class == "Floor") and object.first or object
     -- The triple loop is crappy, but it's the simplest way to check
-    for _, product in pairs(relevant_line.recipe_proto.products) do
+    local function check_product(product)
         for line in self:iterator() do
             for _, ingredient in line.ingredients:iterator() do
                 if ingredient.proto.type == product.type and ingredient.proto.name == product.name then
@@ -193,6 +193,12 @@ function Floor:check_product_compatibility(object)
                 end
             end
         end
+    end
+    for _, product in pairs(relevant_line.products) do
+        if check_product(product) then return true end
+    end
+    for _, product in pairs(relevant_line.byproducts) do
+        if check_product(product) then return true end
     end
     return false
 end

--- a/modfiles/backend/handlers/generator.lua
+++ b/modfiles/backend/handlers/generator.lua
@@ -703,6 +703,7 @@ end
 ---@field fuel_value float
 ---@field stack_size uint?
 ---@field emissions_multiplier double
+---@field burnt_result string?
 
 -- Generates a table containing all fuels that can be used in a burner
 ---@return NamedPrototypesWithCategory<FPFuelPrototype>
@@ -740,7 +741,8 @@ function generator.fuels.generate()
                 category = proto.fuel_category,
                 fuel_value = proto.fuel_value,
                 stack_size = proto.stack_size,
-                emissions_multiplier = proto.fuel_emissions_multiplier
+                emissions_multiplier = proto.fuel_emissions_multiplier,
+                burnt_result = proto.burnt_result and proto.burnt_result.name or nil
             }
             insert_prototype(fuels, fuel, fuel.category)
         end


### PR DESCRIPTION
A line's products are the recipe products plus the burnt result of any
fuel. This reveals the burnt result created by any line you already
have, so that you know to handle it. In the matrix solver you can
process the byproduct as usual (e.g. refilling fluid canisters).

What burnt result will be produced depends on the recipe, the machine,
and the fuel. This does not any recipes which fill demand for the
burnt result (e.g. you need ash, we don't suggest burning coal to make
steam in a boiler). This is pretty wonky, but it's an improvement from
not having ash show up at all. You can fake it by adding a one steam
as an output from your factory, and the extra steam will turn into
a byproduct. Or you can paste the ash-producing line you want in from
another factory and the solver will use it.