### PR TITLE
Prevent shifting Lines above the top element in a subfloor

### DIFF
--- a/modfiles/backend/data/Line.lua
+++ b/modfiles/backend/data/Line.lua
@@ -9,6 +9,8 @@ local SimpleItems = require("backend.data.SimpleItems")
 ---@class Line: Object, ObjectMethods
 ---@field class "Line"
 ---@field parent Floor
+---@field next LineObject?
+---@field previous LineObject?
 ---@field recipe_proto FPRecipePrototype | FPPackedPrototype
 ---@field production_type ProductionType
 ---@field done boolean

--- a/modfiles/changelog.txt
+++ b/modfiles/changelog.txt
@@ -3,10 +3,13 @@ Version: 0.00.00
 Date: 00. 00. 0000
   Features:
     - Added support for burnt items being output as burner fuel is used up (Thanks falsedrow!)
+    -
   Changes:
     -
   Bugfixes:
     - Fixed that beacon module defaults would reset themselves when the active mods changed
+    - Fixed recipes being moved above the top recipe in a subfloor (#312)
+    -
 
 ---------------------------------------------------------------------------------------------------
 Version: 1.1.78

--- a/modfiles/ui/main/production_handler.lua
+++ b/modfiles/ui/main/production_handler.lua
@@ -3,8 +3,19 @@ local Beacon = require("backend.data.Beacon")
 
 -- ** LOCAL UTIL **
 local function handle_line_move_click(player, tags, event)
+    --- @type Line
     local line = OBJECT_INDEX[tags.line_id]
+    local floor = line.parent
+
     local spots_to_shift = (event.control) and 5 or ((not event.shift) and 1 or nil)
+    if spots_to_shift == nil and floor.level > 1 and tags.direction == "previous" then
+        spots_to_shift = 0
+        for previous_line in floor:iterator(nil, line.previous, "previous") do
+            if previous_line.id ~= floor.first.id then
+                spots_to_shift = spots_to_shift + 1
+            end
+        end
+    end
     line.parent:shift(line, tags.direction, spots_to_shift)
 
     solver.update(player)


### PR DESCRIPTION
Fixes #312.

This was a bit of a slapdash solution which doesn't preserve the nice encapsulation that the `Object` -> `Floor` inheritance provides. If this is acceptable, then great! 

However, I was considering the possibility of adding a `.locked` field to `Object` which could be applied to the top level `Line` in a subfloor, which could be checked by `_shift` without having to know about the structure of floors and lines.

Let me know what you think!