### PR TITLE
Get the test scenario loading on 2.0.

### DIFF
--- a/modfiles/backend/handlers/screenshotter.lua
+++ b/modfiles/backend/handlers/screenshotter.lua
@@ -191,6 +191,8 @@ local function execute_action(player_index, action_name)
     actions[action_name](player)
 end
 
+-- Remove first to make file resilient to double load (from test harness)
+remote.remove_interface("screenshotter_input")
 remote.add_interface("screenshotter_input", {
     initial_setup = initial_setup,
     execute_action = execute_action

--- a/modfiles/backend/init.lua
+++ b/modfiles/backend/init.lua
@@ -297,10 +297,13 @@ script.on_event(translator.on_player_dictionaries_ready, dictionaries_ready)
 
 
 -- ** COMMANDS **
+-- Remove first to make file resilient to double load (from test harness)
+commands.remove_command("fp-restart-translation")
 commands.add_command("fp-restart-translation", {"command-help.fp_restart_translation"}, function()
     translator.on_init()
     prototyper.util.build_translation_dictionaries()
 end)
+commands.remove_command("fp-shrinkwrap-interface")
 commands.add_command("fp-shrinkwrap-interface", {"command-help.fp_shrinkwrap_interface"}, function(command)
     if command.player_index then main_dialog.shrinkwrap_interface(game.get_player(command.player_index)) end
 end)

--- a/scenarios/tester/control.lua
+++ b/scenarios/tester/control.lua
@@ -1,8 +1,8 @@
 ---@diagnostic disable
 
 -- ** LLOG **
-llog = require("__factoryplanner__.llog")
-LLOG_EXCLUDES = {}
+--llog = require("__factoryplanner__.llog")
+--LLOG_EXCLUDES = {}
 
 -- ** TESTS **
 local solver_tests = require("solver.tests")
@@ -11,12 +11,12 @@ local function setup()
     game.autosave_enabled = false
     game.speed = 100
 
-    global.runplan = {}
-    global.results = {}
-    global.next_test = 1
+    storage.runplan = {}
+    storage.results = {}
+    storage.next_test = 1
     for _, test_set in pairs{solver_tests} do
         for _, test in ipairs(test_set) do
-            table.insert(global.runplan, test)
+            table.insert(storage.runplan, test)
         end
     end
 end
@@ -24,24 +24,25 @@ end
 local function teardown()
     local failures = ""
 
-    for name, result in pairs(global.results) do
+    for name, result in pairs(storage.results) do
+        print(result)
         if result ~= "pass" then failures = failures .. "\nTest " .. name .. ": " .. result end
     end
 
-    local output = (failures ~= "") and "Passed all " .. #global.runplan .. " tests"
-        or "Failed " .. #failures .. " of " .. #global.runplan .. " tests" .. failures
-    game.write_file("results.txt", output)
+    local output = (failures ~= "") and "Passed all " .. #storage.runplan .. " tests"
+        or "Failed " .. #failures .. " of " .. #storage.runplan .. " tests" .. failures
+    helpers.write_file("results.txt", output)
 
     script.on_event(defines.events.on_tick, nil)
     print("tester_done")  -- let script know to kill Factorio
 end
 
 local function run_test()
-    local test = global.runplan[global.next_test]
+    local test = storage.runplan[storage.next_test]
     if not test then teardown(); return end
 
-    global.results[test.name] = test.runner(test)
-    global.next_test = global.next_test + 1
+    storage.results[test.name] = test.runner(test)
+    storage.next_test = storage.next_test + 1
 end
 
 

--- a/scenarios/tester/solver/parts.lua
+++ b/scenarios/tester/solver/parts.lua
@@ -11,7 +11,7 @@ local parts = {}
 -- Also, these parts are missing lots of things (like the line missing its beacon, for example)
 
 function parts.export_string(setup)
-    return game.table_to_json({
+    return helpers.table_to_json({
         export_modset = {
             base = "1.1.80",
             flib = "0.12.6",

--- a/scenarios/tester/solver/tests.lua
+++ b/scenarios/tester/solver/tests.lua
@@ -6,10 +6,13 @@ local framework = require("solver.framework")
 --      Also, it doesn't work without dumb changes to the main mod, so this whole test
 --      setup is non-functional and untested until the requires are cleaned up
 require("__factoryplanner__.control")  -- pull in all the crap
+local Factory = require("__factoryplanner__.backend.data.Factory")
+local District= require("__factoryplanner__.backend.data.District")
 
 local tests = {
     {
         name = "example_subfactory",
+        -- TODO: This setup data is currently completely ignored, the export_string below is what is used.
         setup = parts.subfactory{
             products = {
                 parts.top_level_product("item", "iron-plate", 10)
@@ -25,17 +28,34 @@ local tests = {
                 }
             }
         },
+        export_string = "eNp9U9uOmzAQ/ZXKz2wEyRICH9CnVlpp+1atkDFD1pJva49XjSL+vWMgK5I0RUjg4zNz5szYZwZ/nPXYatsHQNacWccDsIZtN/mmZhnroYtH3nOH4Bd4S/CgZEfLfFOUmzytuUDrT05xY1bE8bIjIbDm95kJxQP9se8znyIN10nvFwT8VtC6UxGclwaJdqZ4YzHFMtpy3vZRoPyUeGo7a+TMWOBrgZcZnKPQJmeLkvTWPFGhCLQp6HNMhRCOoJNhjrzFk4MFCoQFqZ2Sg4SeNegjjKkvgzTQt10K5dpGk7Q8fETpCV6Qhhq0v37K4rDf7etdnj/XdVUX26p+3pVFWVVVeagOdb7fluNbxtC6dlDW+lT6V9smIGMKPkGxpqA/quLa+Q9CplKEdND+1/3a68x/4PbSeWsu9BmZkljSawauAmSMp/HAHEdh4AUY5EdCijzPmObiPZW3svRzge4HFZAyPw3RGy5uZhU0KJTmeONhSf/AxEfkKp2cWx1jvebqJtVMlo9yDZactUpqiRezQ0wjWc0qre9dCTtprcyId9BS3FWQ8v1TneTpukYF7XJlv1o5oa+QTuLMmO5QChBWa0gHkrHxbaT3L8IaU6g=",
         body = (function(subfactory)
-            return framework.check_top_level_product(subfactory, "iron-plate", 10)
+            -- TODO: This is all very temporary proof-of-concept
+            local EPSILON = 0.00001
+            local expected = 0.16666666666667
+            local ore_ingredient = subfactory.top_floor.ingredients.items[1]
+            if ore_ingredient.proto.name == "iron-ore" and (math.abs(ore_ingredient.amount - expected) < EPSILON) then
+                return "pass"
+
+            else
+                return "Expected " .. expected .. " got " .. ore_ingredient.amount
+            end
+            -- The framework needs to change but I don't know what too yet.
+            --return framework.check_top_level_product(subfactory, "iron-plate", 10)
         end)
     }
 }
 
-
 local function runner(test)
-    local export_string = game.encode_string(parts.export_string(test.setup))
-    local import_factory = util.porter.process_export_string(export_string)  ---@cast import_factory -nil
-    local subfactory = Factory.get(import_factory, "Subfactory", 1)
+    -- This approach doesn't work with the test data as-is because it is too old
+    -- a format to be migrated.
+    --local export_string = helpers.encode_string(parts.export_string(test.setup))
+
+    -- Instead, for now we'll use an export string direct from the game/mod.
+    local import_factory = util.porter.process_export_string(test.export_string)  ---@cast import_factory -nil
+    local subfactory = import_factory.factories[1]
+    -- A district is necessary for a location/pollutant_type
+    subfactory.parent = District.init("Test District")
     if not subfactory.valid then error("Loaded subfactory setup is invalid") end
     solver.update(game.get_player(1), subfactory)  -- jank
 


### PR DESCRIPTION
The testing scenario hadn't been updated for 2.0, and didn't work at all (i.e. was crashing).

This change gets it _technically_ working again, though it avoids the problem of creating factory fixtures. Instead, it shortcuts that process by using a raw export string.

Don't get too excited, this really isn't much. But it's an improvement. A potential negative is that it does technically change the mod code itself, which I was trying to avoid - removing interfaces/commands before adding them - but that strikes me as a pretty safe operation (though redundant in ideal circumstances.) That's caused by this approach needing to re-require `control.lua`.

I haven't yet convinced myself that this approach is the way forward (as you mentioned yourself on discord, it has some Issues), but at least this leaves it in a better place than it was.

# Devlog

## 2024-10-24

GOAL: Set up devenv.

Cloned repo to mod directory.

PROBLEM: Mod doesn't load when launching debug. `modfiles` subdirectory needs to
be at the root level. Renamed repo directory to something else and made a
windows shortcut. Didn't work. Copy+pasted directory to verify it should work.

Found how to create "proper" symlinks on windows:

    New-Item -Path factoryplanner -ItemType SymbolicLink -Value .\factoryplannerrepo\modfiles

Works.

PROBLEM: Scenarios don't show up.

Symlinked `scenarios` directory into `modfiles`. Probably would be cleaner to
symlink into user directory. Reference:
https://wiki.factorio.com/Tutorial:Mod_structure

PROBLEM: misc crashes loading testing scenario. Liberal commenting out and
updating to 2.0 (e.g. `global` to `storage`) got the scenario booting, though
not doing anything.


## 2024-10-25

PROBLEM: Need test suite to actually do something. Start uncommenting and
actually figure out what's going on.

Need to make `Factory` constant available in `tests.lua`.

    local Factory = require("__factoryplanner__.backend.data.Factory")

require works, but has picket up the `init` and `unpack` functions. `get`
doesn't exist anymore, but looking at usage plausible that `unpack` is the
replacement function ... but has a different API.

Hrmm maybe not, looking at type of `import_factory`.

`process_export_string` is returning `nil`, breakpointing to step through it.

We're getting a migration failure.

So: the test fixture data is in an old format. 1.1.42. This is before 1.1.60 which is first migratable version.
So: we need new fixture data. Can we export from mod? Or simply construct by looking at data constructors?

The fixture data is created in `parts.lua`, which hard codes version strings.

Confirmed can export a string from mod proper, so let's use that and try to reverse engineer.

Ok it loads now, but solving fails because factory is not in a district. (Line:get_surface_compatibility)

Let's try regening with a district? Feel like it might still fail coz we're in a testenv and no surfaces?
Actually maybe just looking for compat between district and machines/recipes.

So factory export from ingame mod is specific just to factory and doesn't include district. So we need another way to rehydrate that data.
For now will comment out in `Line` and see if we can make progress.

Found one more line trying to find pollution type, commented that out also.

Altered test body to locate an item in the factory as a proof-of-concept.

Messy, but this _is_ technically testing something now.

The default District initialiser contains a default location, so adding one of
those to the test subfactory lets us remove hacks.

Added print to control.lua so that results are printed to console as well as file.
Pretty sure the code to dump errors to results.txt is broken, but don't care at this point.

PROBLEM: Still have some commented code in the main modfiles that need to be reverted before merge is possible.

Files are being double-required. First by the scenario `control.lua`, second by
the mod `control.lua`. This causes problems when e.g. adding an interface in
`screenshotter.lua`

Really wanted to avoid changing main modfiles, but think need to make them
idempotent by removing commands first. Otherwise need to do a lot of work in
test harness to sort out requires.