### PR TITLE
WIP: Handle negative machine count in the matrix solver

### DIFF
--- a/modfiles/backend/calculation/matrix_engine.lua
+++ b/modfiles/backend/calculation/matrix_engine.lua
@@ -368,6 +368,9 @@ function matrix_engine.run_matrix_solver(factory_data, check_linear_dependence)
                 local col_num = columns.map[line_key]
                  -- want the j-th entry in the last column (output of row-reduction)
                 local machine_count = matrix[col_num][#columns.values+1]
+                if machine_count < 0 then
+                    machine_count = 0
+                end
                 line_aggregate = matrix_engine.get_line_aggregate(line, factory_data.player_index, floor.id,
                     machine_count, false, factory_metadata, free_variables)
             else


### PR DESCRIPTION
Fix #127 
![image](https://github.com/user-attachments/assets/34bf8731-ce48-4670-87fe-a9e139654bef)
I’d want to mark the unusable recipe somehow but am not sure how to do that.

This is not exactly what I meant in https://github.com/ClaudeMetz/FactoryPlanner/issues/127#issuecomment-2411664542 as that is totally unnecessary, just setting the machine count to zero is enough for per-floor data. For totals that doesn’t work sadly as they aren’t computed from floors but are fetched from the matrix directly. This PR changes that but apparently breaks some cases that work currently; I’m trying to figure out what’s wrong.
