### PR TITLE
Support recipe products with no name

### DIFF
--- a/modfiles/backend/calculation/sequential_engine.lua
+++ b/modfiles/backend/calculation/sequential_engine.lua
@@ -12,10 +12,12 @@ local function update_line(line_data, aggregate)
     -- Determine relevant products
     local relevant_products, byproducts = {}, {}
     for _, product in pairs(recipe_proto.products) do
-        if aggregate.Product[product.type][product.name] ~= nil then
-            table.insert(relevant_products, product)
-        else
-            table.insert(byproducts, product)
+        if product.name then
+			if aggregate.Product[product.type][product.name] ~= nil then
+				table.insert(relevant_products, product)
+			else
+				table.insert(byproducts, product)
+			end
         end
     end
 

--- a/modfiles/backend/handlers/generator.lua
+++ b/modfiles/backend/handlers/generator.lua
@@ -723,10 +723,13 @@ function generator.items.generate()
         local type = item.proto.type
         local name = item.proto.name
         table[type] = table[type] or {}
-        table[type][name] = table[type][name] or {}
-        local item_details = table[type][name]
-        -- Determine whether this item is used as a product at least once
-        item_details.is_product = item_details.is_product or item.is_product
+        if item.proto.name then
+			table[type][name] = table[type][name] or {}
+			local item_details = table[type][name]
+            
+			-- Determine whether this item is used as a product at least once
+			item_details.is_product = item_details.is_product or item.is_product
+        end
     end
 
     -- Create a table containing every item that is either a product or an ingredient to at least one recipe

--- a/modfiles/backend/handlers/generator_util.lua
+++ b/modfiles/backend/handlers/generator_util.lua
@@ -43,17 +43,19 @@ local function combine_identical_products(item_list)
 
     for index=#item_list, 1, -1 do
         local item = item_list[index]
-        local touched_item = touched_items[item.type][item.name]
-        if touched_item ~= nil then
-            touched_item.amount = touched_item.amount + item.amount
-            if touched_item.proddable_amount then
-                touched_item.proddable_amount = touched_item.proddable_amount + item.proddable_amount
-            end
+        if item.name then
+			local touched_item = touched_items[item.type][item.name]
+			if touched_item ~= nil then
+				touched_item.amount = touched_item.amount + item.amount
+				if touched_item.proddable_amount then
+					touched_item.proddable_amount = touched_item.proddable_amount + item.proddable_amount
+				end
 
-            -- Using the table.remove function to preserve array-format
-            table.remove(item_list, index)
-        else
-            touched_items[item.type][item.name] = item
+				-- Using the table.remove function to preserve array-format
+				table.remove(item_list, index)
+			else
+				touched_items[item.type][item.name] = item
+			end
         end
     end
 end
@@ -64,7 +66,9 @@ local function create_type_indexed_list(item_list)
     local indexed_list = {item = {}, fluid = {}, entity = {}}  ---@type IndexedItemList
 
     for index, item in pairs(item_list) do
-        indexed_list[item.type][item.name] = {index = index, item = ftable.shallow_copy(item)}
+        if item.name then
+			indexed_list[item.type][item.name] = { index = index, item = ftable.shallow_copy(item) }
+        end
     end
 
     return indexed_list

--- a/modfiles/backend/handlers/loader.lua
+++ b/modfiles/backend/handlers/loader.lua
@@ -48,10 +48,12 @@ local function recipe_map_from(item_type)
 
     for _, recipe in pairs(storage.prototypes.recipes) do
         for _, item in ipairs(recipe[item_type]) do
-            local item_proto = prototyper.util.find("items", item.name, item.type)  ---@cast item_proto -nil
-            map[item_proto.category_id] = map[item_proto.category_id] or {}
-            map[item_proto.category_id][item_proto.id] = map[item_proto.category_id][item_proto.id] or {}
-            map[item_proto.category_id][item_proto.id][recipe.id] = true
+            if item.name then
+                local item_proto = prototyper.util.find("items", item.name, item.type)  ---@cast item_proto -nil
+                map[item_proto.category_id] = map[item_proto.category_id] or {}
+                map[item_proto.category_id][item_proto.id] = map[item_proto.category_id][item_proto.id] or {}
+                map[item_proto.category_id][item_proto.id][recipe.id] = true
+            end
         end
     end
 


### PR DESCRIPTION
Factory Planner crashes in 2.0 when paired with mods that use the new feature https://lua-api.factorio.com/latest/types/ResearchProgressProductPrototype.html. This product causes the recipe to contribute towards a research in progress.

This PR makes Factory Planner ignore recipe products that have no name, such that its existing functionality works as intended without crashing.