### PR TITLE
Super ultrawide support

### DIFF
--- a/modfiles/control.lua
+++ b/modfiles/control.lua
@@ -43,7 +43,7 @@ GLOBAL_HANDLERS = {}  ---@type { [string]: function }
 
 PRODUCTS_PER_ROW_OPTIONS = {5, 6, 7, 8, 9, 10}
 FACTORY_LIST_ROWS_OPTIONS = {20, 22, 24, 26, 28, 30, 32}
-COMPACT_WIDTH_PERCENTAGE = {20, 22, 24, 26, 28, 30, 32, 34, 36}
+COMPACT_WIDTH_PERCENTAGE = {6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36}
 
 TIMESCALE_MAP = {[1] = "second", [60] = "minute"}
 BLANK_EFFECTS = {speed = 0, productivity = 0, quality = 0, consumption = 0, pollution = 0}

--- a/modfiles/prototypes/styles.lua
+++ b/modfiles/prototypes/styles.lua
@@ -85,7 +85,7 @@ styles["fp_table_production"] = {
 
 styles["fp_drop-down_slim"] = {
     type = "dropdown_style",
-    minimal_width = 0,
+    minimal_width = 70,
     height = 24,
     top_padding = -2,
     right_padding = 2,


### PR DESCRIPTION
Adds some additional narrower width percentage selections to get a narrower compact view on super ultra-wide monitors (32:9) that is comparable to the widths that the existing list makes on standard 16:9 monitors.

Note: I'm not positive increasing the minimal_width in the style is the best solution, but without the change the scroll bar makes all the added choices get an ellipsis and not show the whole number.