### PR TITLE
fixed bug where burnt_result was always set to byproduct in the matrix solver

### DIFF
--- a/modfiles/backend/calculation/matrix_engine.lua
+++ b/modfiles/backend/calculation/matrix_engine.lua
@@ -676,7 +676,12 @@ function matrix_engine.get_line_aggregate(line_data, player_index, floor_id, mac
 
         if fuel_proto.burnt_result then
             local burnt = {type="item", name=fuel_proto.burnt_result, amount=fuel_amount}
+            local burnt_key = matrix_engine.get_item_key(burnt.type, burnt.name)
+            if factory_metadata ~= nil and (factory_metadata.byproducts[burnt_key] or free_variables["item_"..burnt_key]) then
             structures.class.add(line_aggregate.Byproduct, burnt, fuel_amount)
+            else
+                structures.class.add(line_aggregate.Product, burnt, fuel_amount)
+            end
         end
 
         energy_consumption = 0  -- set electrical consumption to 0 when fuel is used


### PR DESCRIPTION
The `burnt_result` feature was not implemented correctly in the matrix solver, as it was always being set to a byproduct. Whether the burnt_result is a product or byproduct depends on burnt_result's context within the matrix solver. It should always be set to product unless it is an explicit byproduct or free item. This matches the behavior for how normal recipe outputs also classified.