### PR TITLE
Machine upgrades mod support PoC

### DIFF
--- a/modfiles/backend/data/Line.lua
+++ b/modfiles/backend/data/Line.lua
@@ -182,16 +182,26 @@ function Line:setup_beacon(player)
     end
 end
 
+local has_mupgrades = remote.interfaces["machine-upgrades-get-modifiers"]
 
 ---@return boolean uses_effects
 function Line:uses_beacon_effects(player)
     return self.machine.proto.effect_receiver.uses_beacon_effects
 end
 
-
 function Line:summarize_effects()
     local beacon_effects = (self.beacon) and self.beacon.total_effects or nil
     local merged_effects = util.effects.merge({self.machine.total_effects, beacon_effects})
+    if has_mupgrades then
+	local name = self.machine.proto.name
+	local meffects = remote.call("machine-upgrades-get-modifiers", "get_modifiers", name)
+	-- We use percent, machine upgrades does not.
+	for item, v in pairs(meffects) do
+		meffects[item] = v * 100
+	end
+	merged_effects = util.effects.merge({merged_effects, meffects})
+    end
+
     local limited_effects, indications = util.effects.limit(merged_effects, self.recipe.proto.maximum_productivity)
 
     self.total_effects = limited_effects

--- a/modfiles/backend/data/Line.lua
+++ b/modfiles/backend/data/Line.lua
@@ -195,7 +195,9 @@ function Line:summarize_effects()
     if has_mupgrades then
 	local name = self.machine.proto.name
 	local meffects = remote.call("machine-upgrades-get-modifiers", "get_modifiers", name)
-	local productivity_applicable = self.recipe.proto.allowed_effects["productivity"]
+	local e = self.recipe.proto.allowed_effects
+	local productivity_applicable = false
+	if e ~= nil then productivity_applicable = e["productivity"] end
 	if not productivity_applicable then
 		meffects["productivity"] = 0
 	end

--- a/modfiles/backend/data/Line.lua
+++ b/modfiles/backend/data/Line.lua
@@ -195,6 +195,10 @@ function Line:summarize_effects()
     if has_mupgrades then
 	local name = self.machine.proto.name
 	local meffects = remote.call("machine-upgrades-get-modifiers", "get_modifiers", name)
+	local productivity_applicable = self.recipe.proto.allowed_effects["productivity"]
+	if not productivity_applicable then
+		meffects["productivity"] = 0
+	end
 	-- We use percent, machine upgrades does not.
 	for item, v in pairs(meffects) do
 		meffects[item] = v * 100


### PR DESCRIPTION
This allows machine upgrades added in "[Planet Rubia](https://mods.factorio.com/mod/rubia)" mod to be accounted for when planning. Fixes #749. This needs a matching PR https://github.com/LoupAndSnoop/machine-upgrades/pull/3 to work.

Right now the added bonuses show under "recipe bonuses". I'm not sure if this is what we want. Productivity bonus does not apply to all recipes, only to intermediate products, so maybe it should be under beacon bonuses?