### PR TITLE
Fix fuel category generation

### DIFF
--- a/modfiles/backend/handlers/generator.lua
+++ b/modfiles/backend/handlers/generator.lua
@@ -800,6 +800,7 @@ function generator.machines.generate()
         }
     end
 
+    ---@param machine FPMachinePrototype
     local function insert_machine(machine)
         machine_categories[machine.category] = machine_categories[machine.category] or {}
         table.insert(machine_categories[machine.category], machine)
@@ -1021,9 +1022,6 @@ function generator.fuels.generate()
                 end
             end
         end
-
-        -- If the machine category ends up empty because of this, make sure to remove it
-        if not next(machine_category.members) then machine_prototypes[machine_category.name] = nil end
     end
 
     -- Fill fuel list, implicitly dropping fuels that aren't used by any machine


### PR DESCRIPTION
Fix for #746

When generating the fuel categories, while iterating the machine prototypes, there was an extra delete, causing some machine prototypes to be skipped. This delete is already handled by the `remove_prototype()` deeper in the loop.

@ClaudeMetz Does the generator run on mod update? If not, what should be done to fix existing save files?