### PR TITLE
fix bug where free variables weren't being scaled correctly to max value in row

### DIFF
--- a/modfiles/backend/calculation/matrix_engine.lua
+++ b/modfiles/backend/calculation/matrix_engine.lua
@@ -631,13 +631,15 @@ function matrix_engine.get_matrix(factory_data, rows, columns)
     local free_variables = {}
     for col = 1, #columns.values do
         local num_non_zero = 0
+        local row_containing_free_variable = 0
         for row = 1, #rows.values do
             if matrix[row][col] ~= 0 then
                 num_non_zero = num_non_zero + 1
+                row_containing_free_variable = row
             end
         end
         if num_non_zero == 1 then
-            free_variables[col] = row
+            free_variables[col] = row_containing_free_variable
         end
     end
 

--- a/modfiles/changelog.txt
+++ b/modfiles/changelog.txt
@@ -7,6 +7,7 @@ Date: 00. 00. 0000
     -
   Bugfixes:
     - Fixed a crash caused by an issue with how fuel categories are handled (#764) (Thanks vapopescu!)
+    - Fixed an issue with the matrix solver's numerical scaling (#766) (Thanks scottmsul!)
     - Fixed detection of modules that can be used in beacons being too permissive (#712)
     - Fixed that ingredients with temperature would not be highlighted on hover in the compact dialog (#728)
     - Fixed a couple of issues for mod configurations that don't include any beacons (#686)
@@ -39,7 +40,7 @@ Date: 23. 06. 2026
 Version: 2.0.50
 Date: 19. 04. 2026
   Bugfixes:
-    - Fixed that the matrix solver would not work properly with high energy consumption recipes (#720) (Thanks scottmsul!)
+    - Fixed that the matrix solver would not work properly with high energy consumption recipes (#740) (Thanks scottmsul!)
 
 ---------------------------------------------------------------------------------------------------
 Version: 2.0.49


### PR DESCRIPTION
Therenas had noticed a bug in the matrix solver where a table entry was being set to a variable that didn't exist. This wasn't breaking the matrix solver entirely, as it only affected the recently added scaling logic from [PR 740](https://github.com/ClaudeMetz/FactoryPlanner/pull/740). However, it was preventing free variables from scaling to the max value in the row, which was one of the intended behaviors from PR 740. This new PR fixes this.