### PR TITLE
Cast `SimpleItem` to `TLProduct` on copy/paste

### DIFF
--- a/modfiles/backend/data/DistrictItem.lua
+++ b/modfiles/backend/data/DistrictItem.lua
@@ -10,6 +10,8 @@ local Object = require("backend.data.Object")
 ---@field proto FPItemPrototype
 ---@field production DistrictItemData
 ---@field consumption DistrictItemData
+---@field overall "production" | "consumption"
+---@field abs_diff number
 local DistrictItem = Object.methods()
 DistrictItem.__index = DistrictItem
 script.register_metatable("DistrictItem", DistrictItem)

--- a/modfiles/backend/data/TLProduct.lua
+++ b/modfiles/backend/data/TLProduct.lua
@@ -4,7 +4,7 @@ local Object = require("backend.data.Object")
 
 ---@class TLProduct: Object, ObjectMethods
 ---@field class "TLProduct"
----@field parent Factory
+---@field parent Factory?
 ---@field proto FPItemPrototype | FPPackedPrototype
 ---@field defined_by ProductDefinedBy
 ---@field required_amount number
@@ -15,8 +15,9 @@ TLProduct.__index = TLProduct
 script.register_metatable("TLProduct", TLProduct)
 
 ---@param proto (FPItemPrototype | FPPackedPrototype)?
+---@param amount number?
 ---@return TLProduct
-local function init(proto)
+local function init(proto, amount)
     local this_proto = proto or {
         name = "",
         category = "",
@@ -29,7 +30,9 @@ local function init(proto)
         required_amount = 0,  -- always per second
         belt_proto = nil,
 
-        amount = 0  -- the amount satisfied by the solver
+        amount = 0,  -- the amount satisfied by the solver
+
+        parent = nil
     }, "TLProduct", TLProduct)  --[[@as TLProduct]]
     return object
 end
@@ -68,17 +71,18 @@ end
 ---@return boolean success
 ---@return string? error
 function TLProduct:paste(object)
-    -- TLProduct objects are converted to SimpleItems when copied, so they can't appear here
-    if object.class == "SimpleItem" or object.class == "Fuel" then
-        local proto  ---@type FPItemPrototype | FPPackedPrototype
+    if object.class == "TLProduct" or object.class == "Fuel" then
+        ---@cast object -(Beacon | Floor | Line | Machine | Module)
+        local proto = object.proto  --[[@as FPItemPrototype | FPPackedPrototype]]
         if object.class == "Fuel" then  -- need an Item prototype here, not Fuel
-            proto = prototyper.util.find("items", object:get_name_with_temperature(), object.proto.type) --[[@as FPItemPrototype]]
-        else
-            proto = object.proto  --[[@as FPItemPrototype | FPPackedPrototype]]
+            proto = prototyper.util.find("items", object:get_name_with_temperature(), proto.type) --[[@as FPItemPrototype]]
         end
 
         if proto.simplified then return false, "incompatible" end
         ---@cast proto -FPPackedPrototype
+
+        -- Do not allow pasting on line ingredients
+        if not self.parent then return false, "incompatible" end
 
         -- Avoid duplicate items, but allow pasting over the same item proto
         local existing_item = self.parent:find({proto=proto})
@@ -86,8 +90,7 @@ function TLProduct:paste(object)
             return false, "already_exists"
         end
 
-        local product = init(proto)  -- defined_by = "amount"
-        product.required_amount = object.amount
+        local product = init(proto, object.required_amount)
         self.parent:replace(self, product)
 
         return true, nil
@@ -103,6 +106,7 @@ end
 ---@field defined_by ProductDefinedBy
 ---@field required_amount number
 ---@field belt_proto FPPackedPrototype?
+---@field amount number?
 
 ---@param full boolean
 ---@return PackedProduct packed_self

--- a/modfiles/backend/data/TLProduct.lua
+++ b/modfiles/backend/data/TLProduct.lua
@@ -27,7 +27,7 @@ local function init(proto, amount)
     local object = Object.init({
         proto = this_proto,
         defined_by = "amount",
-        required_amount = 0,  -- always per second
+        required_amount = amount or 0,  -- always per second
         belt_proto = nil,
 
         amount = 0,  -- the amount satisfied by the solver

--- a/modfiles/locale/en/config.cfg
+++ b/modfiles/locale/en/config.cfg
@@ -464,6 +464,7 @@ error_no_compatible_machine="__1__" has no usable machine to craft it
 error_no_subfloor_on_byproduct_recipes=Can’t add a subfloor to recipes that consume byproducts
 error_no_new_subfloors_in_archive=Can’t add a subfloor in archived factories
 error_no_main_recipe_on_subfloor=Can’t add a recipe for a top floor item to a subfloor
+error_copy_temperature_not_configured="__1__" temperature needs to be configured first before it can be copied
 warning_recipe_disabled="__1__" is not researched yet, so you can’t produce that recipe currently
 warning_surface_not_compatible="__1__" is not compatible with the current location and has been disabled
 warning_temperature_not_configured="__1__" has fluid ingredients whose temperatures need to be configured

--- a/modfiles/locale/en/config.cfg
+++ b/modfiles/locale/en/config.cfg
@@ -560,6 +560,8 @@ pl_fluid=__plural_for_parameter__1__{1=fluid|rest=fluids}__
 pu_fluid=__plural_for_parameter__1__{1=Fluid|rest=Fluids}__
 pl_simpleitem=__plural_for_parameter__1__{1=item|rest=items}__
 pu_simpleitem=__plural_for_parameter__1__{1=Item|rest=Items}__
+pl_tlproduct=__plural_for_parameter__1__{1=item|rest=items}__
+pu_tlproduct=__plural_for_parameter__1__{1=Item|rest=Items}__
 pl_product=__plural_for_parameter__1__{1=product|rest=products}__
 pu_product=__plural_for_parameter__1__{1=Product|rest=Products}__
 pl_byproduct=__plural_for_parameter__1__{1=byproduct|rest=byproducts}__

--- a/modfiles/ui/main/districts_box.lua
+++ b/modfiles/ui/main/districts_box.lua
@@ -29,7 +29,7 @@ end
 
 
 local function handle_item_button_click(player, tags, action)
-    local item = OBJECT_INDEX[tags.item_id]
+    local item = OBJECT_INDEX[tags.item_id]  --[[@as DistrictItem]]
 
     if action == "create_factory" then  -- only on net ingredients
         if item.proto.ingredient_only then
@@ -47,9 +47,8 @@ local function handle_item_button_click(player, tags, action)
         main_dialog.toggle_districts_view(player, true)
         lib.gui.run_refresh(player, "all")
 
-    elseif action == "copy" then  -- copy as SimpleItems makes most sense
-        local copyable_item = {class="SimpleItem", proto=item.proto, amount=item.abs_diff}
-        lib.clipboard.copy(player, copyable_item)
+    elseif action == "copy" then
+        lib.clipboard.copy(player, TLProduct.init(item.proto, item.abs_diff))
 
     elseif action == "add_to_cursor" then
         lib.cursor.handle_item_click(player, item.proto, item.abs_diff)

--- a/modfiles/ui/main/item_boxes.lua
+++ b/modfiles/ui/main/item_boxes.lua
@@ -35,6 +35,9 @@ local function build_item_box(player, category, column_count)
     item_boxes_elements[category .. "_item_table"] = table_items
 end
 
+---@param player LuaPlayer
+---@param factory Factory
+---@param show_floor_items boolean
 local function refresh_item_box(player, factory, show_floor_items, item_category, tooltips)
     local item_boxes_elements = lib.globals.main_elements(player).item_boxes
 
@@ -138,12 +141,21 @@ local function handle_item_button_click(player, tags, action)
 
     local item = nil
     if tags.item_id then
-        item = OBJECT_INDEX[tags.item_id]  --[[@as TLProduct]]
+        item = OBJECT_INDEX[tags.item_id]  --[[@as TLProduct | SimpleItem]]
     else
         -- Need to get items from the right floor depending on display settings
         local floor = (show_floor_items) and lib.context.get(player, "Floor")
             or lib.context.get(player, "Factory").top_floor
-        item = floor[tags.item_category .. "s"][tags.item_index]  --[[@as TLProduct]]
+        item = floor[tags.item_category .. "s"][tags.item_index]  --[[@as SimpleItem]]
+    end
+
+    -- Cast SimpleItem to TLProduct for copy/paste
+    local product  ---@type TLProduct
+    if item.class == "SimpleItem" then
+        product = TLProduct.init(item.proto, item.amount)
+    else
+        ---@cast item -SimpleItem
+        product = item
     end
 
     if action == "add_recipe" then
@@ -167,11 +179,10 @@ local function handle_item_button_click(player, tags, action)
         lib.gui.run_refresh(player, "item_boxes")
 
     elseif action == "copy" then
-        local copyable_item = {class="SimpleItem", proto=item.proto, amount=item.amount}
-        lib.clipboard.copy(player, copyable_item)
+        lib.clipboard.copy(player, product)
 
     elseif action == "paste" then
-        lib.clipboard.paste(player, item)
+        lib.clipboard.paste(player, product)
 
     elseif action == "delete" then
         lib.context.get(player, "Factory"):remove(item)
@@ -212,7 +223,7 @@ local function put_ingredients_into_cursor(player, _, _)
     main_dialog.toggle(player)
 end
 
-
+---@param player LuaPlayer
 local function refresh_item_boxes(player)
     local player_table = lib.globals.player_table(player)
 
@@ -223,7 +234,7 @@ local function refresh_item_boxes(player)
     main_elements.item_boxes.horizontal_flow.visible = visible
     if not visible then return end
 
-    local factory = lib.context.get(player, "Factory")  --[[@as Factory?]]
+    local factory = lib.context.get(player, "Factory")  --[[@as Factory]]
     local show_floor_items = player_table.preferences.show_floor_items
 
     local tooltips = player_table.ui_state.tooltips

--- a/modfiles/ui/main/item_boxes.lua
+++ b/modfiles/ui/main/item_boxes.lua
@@ -141,7 +141,7 @@ local function handle_item_button_click(player, tags, action)
 
     local item = nil
     if tags.item_id then
-        item = OBJECT_INDEX[tags.item_id]  --[[@as TLProduct | SimpleItem]]
+        item = OBJECT_INDEX[tags.item_id]  --[[@as TLProduct]]
     else
         -- Need to get items from the right floor depending on display settings
         local floor = (show_floor_items) and lib.context.get(player, "Floor")
@@ -234,7 +234,7 @@ local function refresh_item_boxes(player)
     main_elements.item_boxes.horizontal_flow.visible = visible
     if not visible then return end
 
-    local factory = lib.context.get(player, "Factory")  --[[@as Factory]]
+    local factory = lib.context.get(player, "Factory")  --[[@as Factory?]]
     local show_floor_items = player_table.preferences.show_floor_items
 
     local tooltips = player_table.ui_state.tooltips

--- a/modfiles/ui/main/production_handler.lua
+++ b/modfiles/ui/main/production_handler.lua
@@ -1,5 +1,6 @@
 local Floor = require("backend.data.Floor")
 local Beacon = require("backend.data.Beacon")
+local TLProduct = require("backend.data.TLProduct")
 
 -- ** LOCAL UTIL **
 local function handle_line_move_click(player, tags, event)
@@ -215,8 +216,8 @@ end
 
 
 local function handle_item_click(player, tags, action)
-    local line = OBJECT_INDEX[tags.line_id]
-    local item = line[tags.item_category .. "s"][tags.item_index]
+    local line = OBJECT_INDEX[tags.line_id]  --[[@as Line]]
+    local item = line[tags.item_category .. "s"][tags.item_index]  --[[@as TLProduct | SimpleItem]]
 
     if action == "prioritize" then
         if line.class ~= "Line" then
@@ -265,43 +266,17 @@ local function handle_item_click(player, tags, action)
             category_id=item.proto.category_id, name=item.proto.name}})
 
     elseif action == "copy" then
-        local proto = item.proto
+        local proto = item.proto  --[[@as FPItemPrototype]]
         if item.proto.type == "fluid" and line.class == "Line" then
-            local item_name = line.recipe:get_name_with_temperature(item.proto)
-            proto = prototyper.util.find("items", item_name, "fluid")
+            local item_name = line.recipe:get_name_with_temperature(proto)
+            proto = prototyper.util.find("items", item_name, "fluid")  --[[@as FPItemPrototype]]
         end
 
-        local copyable_item = {class="SimpleItem", proto=proto, amount=item.amount}
-        lib.clipboard.copy(player, copyable_item)
+        lib.clipboard.copy(player, TLProduct.init(proto, item.amount))
 
     elseif action == "paste" then
         if line.class ~= "Line" then return end
-
-        -- Custom wrapper to paste onto since SimpleItem is not a real object
-        local target = {
-            paste = function(self, object)
-                if object.class == "SimpleItem" or object.class == "Fuel" then
-                    if object.proto.type ~= "fluid" or item.proto.type ~= "fluid" then
-                        return false, "incompatible"
-                    end
-
-                    -- SimpleItems will always be a fluid with temperature
-                    if object.class == "SimpleItem" then
-                        if object.proto.base_name ~= item.proto.name then return false, "incompatible" end
-                        line.recipe.temperatures[item.proto.name] = object.proto.temperature
-                    else  -- "Fuel"
-                        if object.proto.name ~= item.proto.name then return false, "incompatible" end
-                        line.recipe.temperatures[item.proto.name] = object.temperature
-                    end
-
-                    return true, nil
-                else
-                    return false, "incompatible_class"
-                end
-            end,
-            class = "Item"
-        }
-        lib.clipboard.paste(player, target)
+        lib.clipboard.paste(player, TLProduct.init())
 
     elseif action == "add_to_cursor" then
         lib.cursor.handle_item_click(player, item.proto, item.amount)

--- a/modfiles/util/clipboard.lua
+++ b/modfiles/util/clipboard.lua
@@ -12,13 +12,14 @@ local unpackers = {
 
 local _clipboard = {}
 
----@alias CopyableObject Floor | Line | Machine | Beacon | Module | Fuel | SimpleItem
----@alias CopyableObjectClass "Floor" | "Line" | "Machine" | "Beacon" | "Module" | "Fuel" | "SimpleItem"
+---@alias CopyableObject Floor | Line | Machine | Beacon | Module | Fuel | TLProduct
+---@alias CopyableObjectClass "Floor" | "Line" | "Machine" | "Beacon" | "Module" | "Fuel" | "TLProduct"
+---@alias CopyablePackedObject PackedFloor | PackedLine | PackedMachine | PackedBeacon | PackedModule | PackedFuel | PackedProduct
 ---@alias CopyableObjectParent Factory | Floor | Line | ModuleSet | Machine
 
 ---@class ClipboardEntry
 ---@field class CopyableObjectClass
----@field packed_object PackedObject
+---@field packed_object CopyablePackedObject
 ---@field parent CopyableObjectParent?
 
 -- Copies the given object into the player's clipboard as a packed object
@@ -28,7 +29,7 @@ function _clipboard.copy(player, object)
     local player_table = lib.globals.player_table(player)
     player_table.clipboard = {
         class = object.class,
-        packed_object = (object.pack ~= nil) and object:pack(true) or object,
+        packed_object = object:pack(true),
         parent = object.parent  -- just used for unpacking, will remain a reference even if deleted elsewhere
     }
 
@@ -45,14 +46,8 @@ function _clipboard.paste(player, target)
     if clip == nil then
         lib.cursor.create_flying_text(player, {"fp.clipboard_empty"})
     else
-        local clone
-        if clip.parent then  -- only real objects have parents
-            clone = unpackers[clip.class](clip.packed_object, clip.parent)  --[[@as CopyableObject]]
-            ---@cast clone -SimpleItem
-            clone:validate()
-        else
-            clone = lib.flib.shallow_copy(clip.packed_object)  --[[@as SimpleItem]]
-        end
+        local clone = unpackers[clip.class](clip.packed_object, clip.parent)  --[[@as CopyableObject]]
+        clone:validate()
         local success, error = target:paste(clone, player)
 
         if success then  -- objects in the clipboard are always valid since it resets on_config_changed

--- a/modfiles/util/clipboard.lua
+++ b/modfiles/util/clipboard.lua
@@ -26,6 +26,13 @@ local _clipboard = {}
 ---@param player LuaPlayer
 ---@param object CopyableObject
 function _clipboard.copy(player, object)
+    -- Only copy fluids with set temperatures
+    if (object.class == "TLProduct" or object.class == "Fuel") and object.proto.type == "fluid" and not object.proto.temperature then
+        log("\n\n.object = " .. serpent.block(object))
+        lib.messages.raise(player, "error", {"fp.error_copy_temperature_not_configured", {"fluid-name." .. object.proto.name, 1}}, 1)
+        return
+    end
+
     local player_table = lib.globals.player_table(player)
     player_table.clipboard = {
         class = object.class,


### PR DESCRIPTION
Some things to consider:
* Class field naming regarding amounts (required and satisfied) is inconsistent (`SimpleItem` - `amount`, `satisfied_amount`; `Fuel` - `amount`, `satisfied_amount`; `TLProduct` - `reqired_amount`, `amount`). Should consider renaming in the future.
* An error is being raised when trying to copy an item with a fluid prototype, but unset temperature. I did this because setting the temperature on a top-level product is currently not supported, and trying to add a recipe for it crashes (bug in the "add_recipe" modal when neither `recipe_id` or `fuel_id` is defined)
* Non-English locales need to be updated separately.