### PR TITLE
Allow pasting SimpleItems on Fuel

### DIFF
--- a/modfiles/backend/data/Fuel.lua
+++ b/modfiles/backend/data/Fuel.lua
@@ -108,6 +108,9 @@ function Fuel:paste(object)
             fuel:build_temperature_data()
             fuel.temperature = object.proto.temperature
         end
+    else
+        -- Only allow pasting items and fuels
+        return false, "incompatible_class"
     end
 
     if fuel then
@@ -120,10 +123,9 @@ function Fuel:paste(object)
                 return true, nil
             end
         end
-        return false, "incompatible"
-    else
-        return false, "incompatible_class"
     end
+
+    return false, "incompatible"
 end
 
 

--- a/modfiles/backend/data/Fuel.lua
+++ b/modfiles/backend/data/Fuel.lua
@@ -105,7 +105,6 @@ function Fuel:paste(object)
         local proto = prototyper.util.find("fuels", object.proto.base_name or object.proto.name, burner.combined_category)  --[[@as FPFuelPrototype?]]
         if proto then
             fuel = init(nil, proto)
-            fuel:build_temperature_data()
             fuel.temperature = object.proto.temperature
         end
     else

--- a/modfiles/backend/data/Fuel.lua
+++ b/modfiles/backend/data/Fuel.lua
@@ -100,8 +100,10 @@ function Fuel:paste(object)
 
     local fuel = nil
     if object.class == "Fuel" then
+        ---@cast object Fuel
         fuel = object
     elseif object.class == "SimpleItem" then
+        ---@cast object SimpleItem
         -- Try to convert SimpleItem to Fuel
         local proto = prototyper.util.find("fuels", object.proto.base_name or object.proto.name, burner.combined_category)  ---@as FPFuelPrototype?
         if proto then

--- a/modfiles/backend/data/Fuel.lua
+++ b/modfiles/backend/data/Fuel.lua
@@ -12,7 +12,7 @@ local Fuel = Object.methods()
 Fuel.__index = Fuel
 script.register_metatable("Fuel", Fuel)
 
----@param parent Machine
+---@param parent Machine?
 ---@param proto (FPFuelPrototype | FPPackedPrototype)?
 ---@return Fuel
 local function init(parent, proto)
@@ -90,19 +90,32 @@ end
 ---@return boolean success
 ---@return string? error
 function Fuel:paste(object)
+    local burner = self.parent.proto.burner
+
+    -- Sanity check. Should exist if fuel can be pasted
+    if burner == nil then
+        return false, "incompatible"
+    end
+
+    local fuel = nil
     if object.class == "Fuel" then
-        local burner = self.parent.proto.burner
-
-        -- Sanity check. Should exist if fuel can be pasted
-        if burner == nil then
-            return false, "incompatible"
+        fuel = object
+    elseif object.class == "SimpleItem" then
+        -- Try to convert SimpleItem to Fuel
+        local proto = prototyper.util.find("fuels", object.proto.base_name or object.proto.name, burner.combined_category)  --[[@as FPFuelPrototype?]]
+        if proto then
+            fuel = init(nil, proto)
+            fuel:build_temperature_data()
+            fuel.temperature = object.proto.temperature
         end
+    end
 
+    if fuel then
         -- Check invididual categories so you can paste between combined_categories
         for category_name, _ in pairs(burner.categories) do
-            if object.proto.category == category_name then
-                self.proto = object.proto
-                self.temperature = object.temperature
+            if fuel.proto.category == category_name then
+                self.proto = fuel.proto
+                self.temperature = fuel.temperature
                 self:build_temperature_data()
                 return true, nil
             end

--- a/modfiles/backend/data/Fuel.lua
+++ b/modfiles/backend/data/Fuel.lua
@@ -93,10 +93,8 @@ end
 function Fuel:paste(object)
     local burner = self.parent.proto.burner
 
-    -- Sanity check. Should exist if fuel can be pasted
-    if burner == nil then
-        return false, "incompatible"
-    end
+    -- Sanity check, should exist if fuel can be pasted
+    if burner == nil then return false, "incompatible" end
 
     local fuel = nil
     if object.class == "Fuel" then

--- a/screenshots/automation/mod-list.json
+++ b/screenshots/automation/mod-list.json
@@ -1,31 +1,28 @@
-
 {
-  "mods": 
-  [
-    
+  "mods": [
     {
       "name": "base",
       "enabled": true
     },
-    
     {
-      "name": "elevated-rails",
+      "name": "factoryplanner",
       "enabled": true
     },
-    
     {
-      "name": "quality",
+      "name": "flib",
       "enabled": true
     },
-    
     {
-      "name": "recycler",
-      "enabled": true
+      "name": "debugadapter",
+      "enabled": false
     },
-    
     {
-      "name": "space-age",
-      "enabled": true
+      "name": "coverage",
+      "enabled": false
+    },
+    {
+      "name": "profiler",
+      "enabled": false
     }
   ]
 }

--- a/screenshots/automation/mod-list.json
+++ b/screenshots/automation/mod-list.json
@@ -1,28 +1,31 @@
+
 {
-  "mods": [
+  "mods": 
+  [
+    
     {
       "name": "base",
       "enabled": true
     },
+    
     {
-      "name": "factoryplanner",
+      "name": "elevated-rails",
       "enabled": true
     },
+    
     {
-      "name": "flib",
+      "name": "quality",
       "enabled": true
     },
+    
     {
-      "name": "debugadapter",
-      "enabled": false
+      "name": "recycler",
+      "enabled": true
     },
+    
     {
-      "name": "coverage",
-      "enabled": false
-    },
-    {
-      "name": "profiler",
-      "enabled": false
+      "name": "space-age",
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
Automatically convert items in clipboard to fuel when pasted.

Fluid fuels tested with `bobpower 3.0.0` installed.