### PR TITLE
Fix line pasting into floors

### DIFF
--- a/modfiles/backend/data/Floor.lua
+++ b/modfiles/backend/data/Floor.lua
@@ -160,16 +160,48 @@ function Floor:check_product_compatibility(object)
     if self.level == 1 then return true end
 
     local relevant_line = (object.class == "Floor") and object.first or object
+
     -- The triple loop is crappy, but it's the simplest way to check
-    for _, product in pairs(relevant_line.recipe.proto.products) do
-        for line in self:iterator() do
-            for _, ingredient in pairs(line.ingredients) do
-                if ingredient.proto.type == product.type and ingredient.proto.name == product.name then
-                    return true
+    if relevant_line.recipe.production_type == "produce" then
+        for _, product in pairs(relevant_line.recipe.proto.products) do
+            for line in self:iterator() do
+                -- Check if pasted line produces an ingredient on a line on this floor
+                for _, ingredient in pairs(line.ingredients) do
+                    if ingredient.proto.type == product.type
+                            and (ingredient.proto.name == product.name or ingredient.proto.name == product.base_name)
+                            and (line.recipe:get_temperature(ingredient.proto) == product.temperature) then
+                        return true
+                    end
+                end
+
+                -- Check if pasted line produces a fuel on a line on this floor
+                if line.machine and line.machine.fuel then
+                    local fuel = line.machine.fuel  ---@type Fuel
+                    if fuel.proto.elem_type == product.type 
+                            and (fuel.proto.name == product.name or fuel.proto.name == product.base_name)
+                            and (fuel.temperature == product.temperature) then
+                        return true
+                    end
                 end
             end
         end
     end
+
+    -- Check if the pasted line consumes any byproduct of a line on this floor
+    if relevant_line.recipe.production_type == "consume" then
+        for _, ingredient in pairs(relevant_line.recipe.proto.ingredients) do
+            for line in self:iterator() do
+                for _, byproduct in pairs(line.byproducts) do
+                    if ingredient.type == byproduct.proto.type and
+                            (ingredient.name == byproduct.proto.name or ingredient.name == byproduct.proto.base_name)
+                            and (relevant_line.recipe:get_temperature(ingredient) == byproduct.proto.temperature) then
+                        return true
+                    end
+                end
+            end
+        end
+    end
+
     return false
 end
 

--- a/modfiles/backend/data/Floor.lua
+++ b/modfiles/backend/data/Floor.lua
@@ -175,8 +175,7 @@ function Floor:check_product_compatibility(object)
     if relevant_line.recipe.production_type == "produce" then
         ---@cast relevant_line.recipe.proto.products -nil
         for _, product in pairs(relevant_line.recipe.proto.products) do
-            for line in self:iterator() do
-                ---@cast line.recipe -nil
+            for line in self:iterator() do  ---@cast line.recipe -nil
                 -- Check if pasted line produces an ingredient on a line on this floor
                 for _, ingredient in pairs(line.ingredients) do
                     if ingredient.proto.type == product.type
@@ -189,7 +188,7 @@ function Floor:check_product_compatibility(object)
                 -- Check if pasted line produces a fuel on a line on this floor
                 if line.machine and line.machine.fuel then
                     local fuel = line.machine.fuel  ---@type Fuel
-                    if fuel.proto.elem_type == product.type 
+                    if fuel.proto.elem_type == product.type
                             and (fuel.proto.name == product.name or fuel.proto.name == product.base_name)
                             and (fuel.temperature == product.temperature) then
                         return true

--- a/modfiles/backend/data/Floor.lua
+++ b/modfiles/backend/data/Floor.lua
@@ -169,11 +169,14 @@ function Floor:check_product_compatibility(object)
     if self.level == 1 then return true end
 
     local relevant_line = (object.class == "Floor") and object.first or object
+    ---@cast relevant_line.recipe -nil
 
     -- The triple loop is crappy, but it's the simplest way to check
     if relevant_line.recipe.production_type == "produce" then
+        ---@cast relevant_line.recipe.proto.products -nil
         for _, product in pairs(relevant_line.recipe.proto.products) do
             for line in self:iterator() do
+                ---@cast line.recipe -nil
                 -- Check if pasted line produces an ingredient on a line on this floor
                 for _, ingredient in pairs(line.ingredients) do
                     if ingredient.proto.type == product.type
@@ -198,6 +201,7 @@ function Floor:check_product_compatibility(object)
 
     -- Check if the pasted line consumes any byproduct of a line on this floor
     if relevant_line.recipe.production_type == "consume" then
+        ---@cast relevant_line.recipe.proto.ingredients -nil
         for _, ingredient in pairs(relevant_line.recipe.proto.ingredients) do
             for line in self:iterator() do
                 for _, byproduct in pairs(line.byproducts) do

--- a/modfiles/backend/data/Object.lua
+++ b/modfiles/backend/data/Object.lua
@@ -7,7 +7,6 @@
 ---@field parent Object?
 ---@field next Object?
 ---@field previous Object?
----@field dummy boolean? used by clipboard
 
 ---@class ObjectMethods
 local methods = {}

--- a/modfiles/changelog.txt
+++ b/modfiles/changelog.txt
@@ -7,6 +7,7 @@ Date: 00. 00. 0000
     - The matrix solver now allows manual removal of unrestricted items when entering a linear dependence state, instead of resetting them (#586) (Thanks scottmsul!)
   Bugfixes:
     - Fixed a crash caused by an issue with how fuel categories are handled (#764) (Thanks vapopescu!)
+    - Fixed an issue resulting from failing to paste a line onto an empty floor (#773) (Thanks vapopescu!)
     - Fixed an issue with the matrix solver's numerical scaling (#766) (Thanks scottmsul!)
     - Fixed detection of modules that can be used in beacons being too permissive (#712)
     - Fixed that ingredients with temperature would not be highlighted on hover in the compact dialog (#728)

--- a/modfiles/ui/base/main_dialog.lua
+++ b/modfiles/ui/base/main_dialog.lua
@@ -272,12 +272,14 @@ listeners.player = {
 listeners.game = {
     on_singleplayer_init = (function(_)
         for _, player in pairs(game.players) do
+            lib.context.validate(player)  -- for robustness
             main_dialog.rebuild(player, false)
         end
     end),
 
     on_multiplayer_init = (function(_)
         for _, player in pairs(game.players) do
+            lib.context.validate(player)  -- for robustness
             main_dialog.rebuild(player, false)
         end
     end)

--- a/modfiles/ui/base/main_dialog.lua
+++ b/modfiles/ui/base/main_dialog.lua
@@ -293,14 +293,12 @@ listeners.player = {
 listeners.game = {
     on_singleplayer_init = function(_)
         for _, player in pairs(game.players) do
-            lib.context.validate(player)  -- for robustness
             main_dialog.rebuild(player, false)
         end
     end,
 
     on_multiplayer_init = function(_)
         for _, player in pairs(game.players) do
-            lib.context.validate(player)  -- for robustness
             main_dialog.rebuild(player, false)
         end
     end

--- a/modfiles/util/clipboard.lua
+++ b/modfiles/util/clipboard.lua
@@ -39,11 +39,13 @@ end
 -- Tries pasting the player's clipboard content onto the given target
 ---@param player LuaPlayer
 ---@param target CopyableObject
+---@return boolean success
 function _clipboard.paste(player, target)
     local clip = lib.globals.player_table(player).clipboard
 
     if clip == nil then
         lib.cursor.create_flying_text(player, {"fp.clipboard_empty"})
+        return false
     else
         local clone
         if clip.parent then  -- only real objects have parents
@@ -74,6 +76,7 @@ function _clipboard.paste(player, target)
                 lib.cursor.create_flying_text(player, {"fp.clipboard_recipe_irrelevant"})
             end
         end
+        return success
     end
 end
 
@@ -81,11 +84,10 @@ end
 ---@param dummy CopyableObject
 ---@param parent CopyableObjectParent
 function _clipboard.dummy_paste(player, dummy, parent)
-    dummy.dummy = true
     parent:insert(dummy)
-    _clipboard.paste(player, dummy)
-    local last = parent:find_last()
-    if last.dummy then parent:remove(last) end
+    if not _clipboard.paste(player, dummy) then
+        parent:remove(dummy, true)
+    end
 end
 
 ---@param player LuaPlayer

--- a/modfiles/util/clipboard.lua
+++ b/modfiles/util/clipboard.lua
@@ -86,6 +86,7 @@ end
 function _clipboard.dummy_paste(player, dummy, parent)
     parent:insert(dummy)
     if not _clipboard.paste(player, dummy) then
+        -- Prevent collapsing the floor on `Floor:remove()`
         parent:remove(dummy, true)
     end
 end


### PR DESCRIPTION
- Fix a bug which would morph the current floor back into a line when failing to paste on an empty floor. This in turn causes 2 issues:
  - Context corruption on save + reload (GUI is open on a deleted floor)
  - A second paste attempt would paste in a floor above.
- Improved the line pasting check for relevancy on the current floor.