### PR TITLE
Fix fluid picker

### DIFF
--- a/modfiles/ui/dialogs/recipe_dialog.lua
+++ b/modfiles/ui/dialogs/recipe_dialog.lua
@@ -432,7 +432,7 @@ local function open_recipe_dialog(player, modal_data)
         if modal_data.recipe_id then
             local recipe = OBJECT_INDEX[modal_data.recipe_id]  ---@as Recipe
             temperature_data = recipe.temperature_data[modal_data.base_fluid.name]
-        else  ---@cast modal_data.fuel_id -nil
+        elseif modal_data.fuel_id then
             local fuel = OBJECT_INDEX[modal_data.fuel_id]  ---@as Fuel
             temperature_data = fuel.temperature_data
         end


### PR DESCRIPTION
Fix crash when show unbarrelling recipes is enabled and picking 'Crude oil' to add a mining recipe