### PR TITLE
Allow resource mining pseudo-recipes to use modules

### DIFF
--- a/modfiles/backend/handlers/generator.lua
+++ b/modfiles/backend/handlers/generator.lua
@@ -203,6 +203,7 @@ function generator.recipes.generate()
             recipe.sprite = main_product.type .. "/" .. main_product.name
             recipe.order = proto.order
             recipe.categories = {[proto.resource_category] = true}
+            recipe.allowed_effects = {speed=true, productivity=true, quality=true, consumption=true, pollution=true}
             recipe.productivity_recipe = (any_mining_productivity) and "custom-mining" or nil
 
             local ingredients = {{type="entity", name="custom-" .. proto.name, amount=1}--[[@as Ingredient]]}

--- a/modfiles/changelog.txt
+++ b/modfiles/changelog.txt
@@ -2,11 +2,11 @@
 Version: 0.00.00
 Date: 00. 00. 0000
   Features:
-    - 
+    -
   Changes:
-    - 
+    -
   Bugfixes:
-    - 
+    - Fixed mining recipes no longer being marked as accepting any modules (#788) (Thanks vapopescu!)
 
 ---------------------------------------------------------------------------------------------------
 Version: 2.1.4


### PR DESCRIPTION
Fix issue where there are no modules to select for miners and pumpjacks