### PR TITLE
Fix SimpleItem copy

### DIFF
--- a/modfiles/backend/data/TLProduct.lua
+++ b/modfiles/backend/data/TLProduct.lua
@@ -77,7 +77,7 @@ function TLProduct:paste(object)
         if object.class == "Fuel" then  -- need an Item prototype here, not Fuel
             proto = prototyper.util.find("items", object:get_name_with_temperature(), object.proto.type)  ---@as FPItemPrototype
         else
-            proto = prototyper.util.validate_prototype_object(object.proto, "type")  ---@as FPItemPrototype | FPPackedPrototype
+            proto = object.proto  ---@as FPItemPrototype | FPPackedPrototype
         end
 
         if proto.simplified then return false, "incompatible" end

--- a/modfiles/util/clipboard.lua
+++ b/modfiles/util/clipboard.lua
@@ -55,6 +55,7 @@ function _clipboard.paste(player, target)
             clone:validate(player)
         else
             clone = lib.flib.shallow_copy(clip.packed_object)  ---@as SimpleItem
+            clone.proto = prototyper.util.validate_prototype_object(clone.proto, "type")  ---@as FPItemPrototype
         end
         local success, error = target:paste(clone, player)
 


### PR DESCRIPTION
#852 was a fix for TLProducts, but after looking at the cause of the bug a bit more, I found out that all SimpleItem copies were affected.

The bug was introduced by #835. Because the `SimpleItem` class now has a `pack()` method, the clipboard utility now also packs simple items on copy (which is not inherently bad), but I didn't handle this new behavior on paste. Now, that is fixed.